### PR TITLE
chore: Platform check in legacy wrapper

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -156,7 +156,7 @@ class LegacyCordovaBridge {
     }
   }
   getDirectoryTypeFrom(isInternal, isTemporary) {
-    if (cordova.platformId == "android") {
+    if (this.getPlatformId() == "android") {
       if (isInternal) {
         return isTemporary ? Directory.Cache : Directory.Data;
       }
@@ -248,6 +248,15 @@ class LegacyCordovaBridge {
    */
   isSynapseDefined() {
     return typeof CapacitorUtils !== "undefined";
+  }
+  /**
+   * @return the platform id that the app is running on
+   */
+  getPlatformId() {
+    if (typeof Capacitor !== "undefined") {
+      return Capacitor.getPlatform();
+    }
+    return cordova.platformId;
   }
 }
 const LegacyMigration = new LegacyCordovaBridge();

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -158,7 +158,7 @@
       }
     }
     getDirectoryTypeFrom(isInternal, isTemporary) {
-      if (cordova.platformId == "android") {
+      if (this.getPlatformId() == "android") {
         if (isInternal) {
           return isTemporary ? Directory.Cache : Directory.Data;
         }
@@ -250,6 +250,15 @@
      */
     isSynapseDefined() {
       return typeof CapacitorUtils !== "undefined";
+    }
+    /**
+     * @return the platform id that the app is running on
+     */
+    getPlatformId() {
+      if (typeof Capacitor !== "undefined") {
+        return Capacitor.getPlatform();
+      }
+      return cordova.platformId;
     }
   }
   const LegacyMigration = new LegacyCordovaBridge();

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -154,7 +154,7 @@ class LegacyCordovaBridge {
     }
   }
   getDirectoryTypeFrom(isInternal, isTemporary) {
-    if (cordova.platformId == "android") {
+    if (this.getPlatformId() == "android") {
       if (isInternal) {
         return isTemporary ? Directory.Cache : Directory.Data;
       }
@@ -246,6 +246,15 @@ class LegacyCordovaBridge {
    */
   isSynapseDefined() {
     return typeof CapacitorUtils !== "undefined";
+  }
+  /**
+   * @return the platform id that the app is running on
+   */
+  getPlatformId() {
+    if (typeof Capacitor !== "undefined") {
+      return Capacitor.getPlatform();
+    }
+    return cordova.platformId;
   }
 }
 const LegacyMigration = new LegacyCordovaBridge();

--- a/packages/outsystems-wrapper/src/legacyCordova.ts
+++ b/packages/outsystems-wrapper/src/legacyCordova.ts
@@ -194,7 +194,7 @@ class LegacyCordovaBridge {
 
     private getDirectoryTypeFrom(isInternal: boolean, isTemporary: boolean): Directory {
         // @ts-ignore
-        if (cordova.platformId == 'android') {
+        if (this.getPlatformId() == 'android') {
             if (isInternal) {
                 return isTemporary ? Directory.Cache : Directory.Data
             }
@@ -313,6 +313,18 @@ class LegacyCordovaBridge {
         //  So we need to call the Capacitor plugin directly; hence the need for this method
         // @ts-ignore
         return typeof (CapacitorUtils) !== "undefined"
+    }
+
+    /**
+     * @return the platform id that the app is running on
+     */
+    private getPlatformId(): string {
+        // @ts-ignore
+        if (typeof(Capacitor) !== "undefined") {
+            // @ts-ignore
+            return Capacitor.getPlatform();
+        }
+        return cordova.platformId;
     }
 }
 


### PR DESCRIPTION
This is a small PR that updates the retrieval of the platform id in `legacyCordova` outsystems wrapper.

Without this PR, an issue could happen where users update to MABS 12 but are still using the deprecated client actions in the File Plugin, and it may not behave correctly.