### PR TITLE
fix: Add final separator to legacy createDirectory

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -27,7 +27,11 @@ class LegacyCordovaBridge {
       recursive: true
     };
     let getUriSuccess = (uri) => {
-      success(uri);
+      let uriToReturn = uri;
+      if (!uri.endsWith("/")) {
+        uriToReturn = uri + "/";
+      }
+      success(uriToReturn);
     };
     let mkDirSuccess = () => {
       this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -29,7 +29,11 @@
         recursive: true
       };
       let getUriSuccess = (uri) => {
-        success(uri);
+        let uriToReturn = uri;
+        if (!uri.endsWith("/")) {
+          uriToReturn = uri + "/";
+        }
+        success(uriToReturn);
       };
       let mkDirSuccess = () => {
         this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -25,7 +25,11 @@ class LegacyCordovaBridge {
       recursive: true
     };
     let getUriSuccess = (uri) => {
-      success(uri);
+      let uriToReturn = uri;
+      if (!uri.endsWith("/")) {
+        uriToReturn = uri + "/";
+      }
+      success(uriToReturn);
     };
     let mkDirSuccess = () => {
       this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);

--- a/packages/outsystems-wrapper/src/legacyCordova.ts
+++ b/packages/outsystems-wrapper/src/legacyCordova.ts
@@ -12,7 +12,11 @@ class LegacyCordovaBridge {
         }
 
         let getUriSuccess = (uri: string) => { 
-            success(uri)
+            let uriToReturn = uri;
+            if (!uri.endsWith('/')) {
+                uriToReturn = uri + '/'
+            }
+            success(uriToReturn)
         }
         let mkDirSuccess = () => {            
             this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary)
@@ -324,6 +328,7 @@ class LegacyCordovaBridge {
             // @ts-ignore
             return Capacitor.getPlatform();
         }
+        // @ts-ignore
         return cordova.platformId;
     }
 }


### PR DESCRIPTION
Previous cordova plugin was having a '/' at the end of a directory Uri for the `getFile`:

- [Source for Android](https://github.com/OutSystems/cordova-plugin-file/blob/outsystems/src/android/LocalFilesystem.java#L142)
- Doesn't seem to be added natively in iOS, but it is then added [in Javascript bridge](https://github.com/OutSystems/cordova-plugin-file/blob/outsystems/www/DirectoryEntry.js#L40).

The deprecated legacy action call's the new `getUri` (both on the new cordova plugin of this repo and [the capacitor plugin](https://github.com/ionic-team/capacitor-filesystem)), which does not add a '/' at the end, which can cause unexpected bugs in OutSystems apps. In our sample app, it was causing the downloaded file path to be ".../DownloadsSampleText.txt" instead of ".../Downloads/SampleText.txt".

This is a tentative fix on the wrapper, but it may not fix the issue fully - for example in OutSystems plugin the new `GetFileUri` would not have the final '/' separator, and users could unknowingly run into this issue when migrating to the new client actions.

We should probably fix it in the native library themselves.
Although, because currently in Capacitor plugin the '/' does not get added in the end, we should mention it in the release notes, and in case users concat a file with the result of a directory `getUri`, to avoid adding a '/' at the end.