### PR TITLE
fix(ios): rename Constants struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1]
+
+### 27-05-2025
+
+- Fix: Duplicated `Constants` struct build error on iOS.
+
 ## [1.0.0]
 
 ### 26-05-2025

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.filesystem",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/ios/IONFILEStructures+Converters.swift
+++ b/packages/cordova-plugin/ios/IONFILEStructures+Converters.swift
@@ -3,9 +3,9 @@ import IONFilesystemLib
 extension IONFILEStringEncoding {
     static func create(from text: String?) -> Self? {
         switch text {
-        case Constants.StringEncodingValue.ascii: .ascii
-        case Constants.StringEncodingValue.utf16: .utf16
-        case Constants.StringEncodingValue.utf8: .utf8
+        case OSFileConstants.StringEncodingValue.ascii: .ascii
+        case OSFileConstants.StringEncodingValue.utf16: .utf16
+        case OSFileConstants.StringEncodingValue.utf8: .utf8
         default: nil
         }
     }
@@ -14,11 +14,11 @@ extension IONFILEStringEncoding {
 extension IONFILEDirectoryType {
     static func create(from text: String?) -> Self? {
         switch text {
-        case Constants.DirectoryTypeValue.cache: .cache
-        case Constants.DirectoryTypeValue.data, Constants.DirectoryTypeValue.documents, Constants.DirectoryTypeValue.external, Constants.DirectoryTypeValue.externalCache, Constants.DirectoryTypeValue.externalStorage: .document
-        case Constants.DirectoryTypeValue.library: .library
-        case Constants.DirectoryTypeValue.libraryNoCloud: .notSyncedLibrary
-        case Constants.DirectoryTypeValue.temporary: .temporary
+        case OSFileConstants.DirectoryTypeValue.cache: .cache
+        case OSFileConstants.DirectoryTypeValue.data, OSFileConstants.DirectoryTypeValue.documents, OSFileConstants.DirectoryTypeValue.external, OSFileConstants.DirectoryTypeValue.externalCache, OSFileConstants.DirectoryTypeValue.externalStorage: .document
+        case OSFileConstants.DirectoryTypeValue.library: .library
+        case OSFileConstants.DirectoryTypeValue.libraryNoCloud: .notSyncedLibrary
+        case OSFileConstants.DirectoryTypeValue.temporary: .temporary
         default: nil
         }
     }
@@ -73,12 +73,12 @@ extension IONFILEItemAttributeModel {
     typealias JSResult = [String: Any]
     func toJSResult(with url: URL) -> JSResult {
         [
-            Constants.ItemAttributeJSONKey.name: url.lastPathComponent,
-            Constants.ItemAttributeJSONKey.type: type.description,
-            Constants.ItemAttributeJSONKey.size: size,
-            Constants.ItemAttributeJSONKey.ctime: UInt64(creationDateTimestamp.rounded()),
-            Constants.ItemAttributeJSONKey.mtime: UInt64(modificationDateTimestamp.rounded()),
-            Constants.ItemAttributeJSONKey.uri: url.absoluteString
+            OSFileConstants.ItemAttributeJSONKey.name: url.lastPathComponent,
+            OSFileConstants.ItemAttributeJSONKey.type: type.description,
+            OSFileConstants.ItemAttributeJSONKey.size: size,
+            OSFileConstants.ItemAttributeJSONKey.ctime: UInt64(creationDateTimestamp.rounded()),
+            OSFileConstants.ItemAttributeJSONKey.mtime: UInt64(modificationDateTimestamp.rounded()),
+            OSFileConstants.ItemAttributeJSONKey.uri: url.absoluteString
         ]
     }
 }
@@ -86,9 +86,9 @@ extension IONFILEItemAttributeModel {
 extension IONFILEItemType {
     var description: String {
         switch self {
-        case .directory: Constants.FileItemTypeValue.directory
-        case .file: Constants.FileItemTypeValue.file
-        @unknown default: Constants.FileItemTypeValue.fallback
+        case .directory: OSFileConstants.FileItemTypeValue.directory
+        case .file: OSFileConstants.FileItemTypeValue.file
+        @unknown default: OSFileConstants.FileItemTypeValue.fallback
         }
     }
 }

--- a/packages/cordova-plugin/ios/OSFileConstants.swift
+++ b/packages/cordova-plugin/ios/OSFileConstants.swift
@@ -1,4 +1,4 @@
-struct Constants {
+struct OSFileConstants {
     struct ConfigurationValue {
         static let endOfFile = ""
     }

--- a/packages/cordova-plugin/ios/OSFileError.swift
+++ b/packages/cordova-plugin/ios/OSFileError.swift
@@ -25,8 +25,8 @@ enum OSFileError: Error {
 
     func toDictionary() -> [String: String] {
             [
-                Constants.ErrorKey.code: "OS-PLUG-FILE-\(String(format: "%04d", code))",
-                Constants.ErrorKey.message: description
+                OSFileConstants.ErrorKey.code: "OS-PLUG-FILE-\(String(format: "%04d", code))",
+                OSFileConstants.ErrorKey.message: description
             ]
         }
 }

--- a/packages/cordova-plugin/ios/OSFileOperationExecutor.swift
+++ b/packages/cordova-plugin/ios/OSFileOperationExecutor.swift
@@ -21,13 +21,13 @@ class OSFileOperationExecutor {
             switch operation {
             case .readFile(let url, let encoding):
                 let fullData = try service.readEntireFile(atURL: url, withEncoding: encoding).textValue
-                resultData = [Constants.ResultDataKey.data: fullData]
+                resultData = [OSFileConstants.ResultDataKey.data: fullData]
             case .readFileInChunks(let url, let encoding, let chunkSize):
                 try processFileInChunks(at: url, withEncoding: encoding, chunkSize: chunkSize, for: operation, command)
                 return
             case .write(let url, let encodingMapper, let recursive):
                 try service.saveFile(atURL: url, withEncodingAndData: encodingMapper, includeIntermediateDirectories: recursive)
-                resultData = [Constants.ResultDataKey.uri: url.absoluteString]
+                resultData = [OSFileConstants.ResultDataKey.uri: url.absoluteString]
             case .append(let url, let encodingMapper, let recursive):
                 try service.appendData(encodingMapper, atURL: url, includeIntermediateDirectories: recursive)
             case .delete(let url):
@@ -39,16 +39,16 @@ class OSFileOperationExecutor {
             case .readdir(let url):
                 let directoryAttributes = try service.listDirectory(atURL: url)
                     .map { try fetchItemAttributesJSObject(using: service, atURL: $0) }
-                resultData = [Constants.ResultDataKey.files: directoryAttributes]
+                resultData = [OSFileConstants.ResultDataKey.files: directoryAttributes]
             case .stat(let url):
                 resultData = try fetchItemAttributesJSObject(using: service, atURL: url)
             case .getUri(let url):
-                resultData = [Constants.ResultDataKey.uri: url.absoluteString]
+                resultData = [OSFileConstants.ResultDataKey.uri: url.absoluteString]
             case .rename(let source, let destination):
                 try service.renameItem(fromURL: source, toURL: destination)
             case .copy(let source, let destination):
                 try service.copyItem(fromURL: source, toURL: destination)
-                resultData = [Constants.ResultDataKey.uri: destination.absoluteString]
+                resultData = [OSFileConstants.ResultDataKey.uri: destination.absoluteString]
             }
 
             status = .success(data: resultData)
@@ -67,12 +67,12 @@ private extension OSFileOperationExecutor {
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .finished:
-                    self.commandDelegate.handle(command, status: .success(data: [Constants.ResultDataKey.data: Constants.ConfigurationValue.endOfFile]))
+                    self.commandDelegate.handle(command, status: .success(data: [OSFileConstants.ResultDataKey.data: OSFileConstants.ConfigurationValue.endOfFile]))
                 case .failure(let error):
                     self.commandDelegate.handle(command, status: .failure(self.mapError(error, for: operation)))
                 }
             }, receiveValue: {
-                self.commandDelegate.handle(command, status: .success(shouldKeepCallback: true, data: [Constants.ResultDataKey.data: $0.textValue]))
+                self.commandDelegate.handle(command, status: .success(shouldKeepCallback: true, data: [OSFileConstants.ResultDataKey.data: $0.textValue]))
             })
             .store(in: &cancellables)
     }

--- a/packages/cordova-plugin/package-lock.json
+++ b/packages/cordova-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.outsystems.plugins.filesystem",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.outsystems.plugins.filesystem",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@capacitor/synapse": "^1.0.2"

--- a/packages/cordova-plugin/package.json
+++ b/packages/cordova-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.outsystems.plugins.filesystem",
   "displayName": "Filesystem",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Filesystem plugin for Cordova",
   "scripts": {
     "lint": "npm run eslint && npm run prettier -- --check",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.filesystem" version="1.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.filesystem" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFilePlugin</name>
     <description>OutSystems' cordova geolocation plugin</description>
     <author>OutSystems Inc</author>


### PR DESCRIPTION
## Description

The `OSFileConstants` has an struct called `Constants`, which could cause issues with duplicate structs declared in other plugins. E.g. the [geolocation plugin](https://github.com/ionic-team/cordova-outsystems-geolocation/blob/1.0.1/packages/cordova-plugin/ios/OSGeolocationConstants.swift) has one of the same name, and this can cause the build to fail - e.g. see https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=4de2601e5fda2639693c1559eb89d3518616db85&stg=qa

This PR updates the struct name to not cause conflicts.


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
