### PR TITLE
RMET-4294 :: Fix usage of Synapse in OutSystems wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### 01-07-2025
+
+- Fix: Usage of Synapse in OutSystems wrapper.
+
 ## [1.0.1]
 
 ### 27-05-2025

--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -32,7 +32,7 @@ class LegacyCordovaBridge {
     let mkDirSuccess = () => {
       this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.mkdir(mkDirSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.mkdir(options).then(mkDirSuccess).catch(error);
@@ -45,7 +45,7 @@ class LegacyCordovaBridge {
       directory,
       recursive: true
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -71,7 +71,7 @@ class LegacyCordovaBridge {
       );
       success(directories, files);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readdir(readDirSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readdir(options).then(readDirSuccess).catch(error);
@@ -101,7 +101,7 @@ class LegacyCordovaBridge {
       type = this.getMimeType(res.name);
       this.readFile(readFileSuccess, error, path, void 0, void 0);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.stat(statSuccess, error, { path });
     } else {
       Capacitor.Plugins.Filesystem.stat({ path }).then(statSuccess).catch(error);
@@ -116,7 +116,7 @@ class LegacyCordovaBridge {
     let getUriSuccess = (res) => {
       success(res.uri);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.getUri(getUriSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.getUri(options).then(getUriSuccess).catch(error);
@@ -130,7 +130,7 @@ class LegacyCordovaBridge {
       directory,
       recursive: true
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -142,7 +142,7 @@ class LegacyCordovaBridge {
       path: `${path}/${name}`,
       directory
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -244,9 +244,12 @@ class LegacyCordovaBridge {
     return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
   }
   /**
-   * @returns true if synapse is defined, false otherwise
+   * @returns true if synapse is defined and can be used, false otherwise
    */
-  isSynapseDefined() {
+  canUseSynapse() {
+    if (this.isCapacitorPluginDefined()) {
+      return false;
+    }
     return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
   }
   /**
@@ -784,7 +787,7 @@ class OSFilePlugin {
       this.webPlugin.readFile(options).then((file) => success(file)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readFile(options).then(success).catch(error);
@@ -795,7 +798,7 @@ class OSFilePlugin {
       this.webPlugin.writeFile(options).then((result) => success(result)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -806,7 +809,7 @@ class OSFilePlugin {
       this.webPlugin.appendFile(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.appendFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.appendFile(options).then(success).catch(error);
@@ -817,7 +820,7 @@ class OSFilePlugin {
       this.webPlugin.deleteFile(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -828,7 +831,7 @@ class OSFilePlugin {
       this.webPlugin.mkdir(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.mkdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.mkdir(options).then(success).catch(error);
@@ -839,7 +842,7 @@ class OSFilePlugin {
       this.webPlugin.rmdir(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -850,7 +853,7 @@ class OSFilePlugin {
       this.webPlugin.readdir(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readdir(options).then(success).catch(error);
@@ -861,7 +864,7 @@ class OSFilePlugin {
       this.webPlugin.getUri(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.getUri(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.getUri(options).then(success).catch(error);
@@ -872,7 +875,7 @@ class OSFilePlugin {
       this.webPlugin.stat(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.stat(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.stat(options).then(success).catch(error);
@@ -883,7 +886,7 @@ class OSFilePlugin {
       this.webPlugin.rename(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rename(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rename(options).then(success).catch(error);
@@ -894,7 +897,7 @@ class OSFilePlugin {
       this.webPlugin.copy(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.copy(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.copy(options).then(success).catch(error);
@@ -904,7 +907,7 @@ class OSFilePlugin {
    * @returns true if should use the web implementation
    */
   shouldUseCordovaWebImplementation() {
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       return false;
     }
     if (this.isCapacitorPluginDefined()) {
@@ -919,9 +922,12 @@ class OSFilePlugin {
     return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
   }
   /**
-   * @returns true if synapse is defined, false otherwise
+   * @returns true if synapse is defined and can be used, false otherwise
    */
-  isSynapseDefined() {
+  canUseSynapse() {
+    if (this.isCapacitorPluginDefined()) {
+      return false;
+    }
     return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
   }
 }

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -34,7 +34,7 @@
       let mkDirSuccess = () => {
         this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.mkdir(mkDirSuccess, error, options);
       } else {
         Capacitor.Plugins.Filesystem.mkdir(options).then(mkDirSuccess).catch(error);
@@ -47,7 +47,7 @@
         directory,
         recursive: true
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -73,7 +73,7 @@
         );
         success(directories, files);
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.readdir(readDirSuccess, error, options);
       } else {
         Capacitor.Plugins.Filesystem.readdir(options).then(readDirSuccess).catch(error);
@@ -103,7 +103,7 @@
         type = this.getMimeType(res.name);
         this.readFile(readFileSuccess, error, path, void 0, void 0);
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.stat(statSuccess, error, { path });
       } else {
         Capacitor.Plugins.Filesystem.stat({ path }).then(statSuccess).catch(error);
@@ -118,7 +118,7 @@
       let getUriSuccess = (res) => {
         success(res.uri);
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.getUri(getUriSuccess, error, options);
       } else {
         Capacitor.Plugins.Filesystem.getUri(options).then(getUriSuccess).catch(error);
@@ -132,7 +132,7 @@
         directory,
         recursive: true
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -144,7 +144,7 @@
         path: `${path}/${name}`,
         directory
       };
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -246,9 +246,12 @@
       return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
     }
     /**
-     * @returns true if synapse is defined, false otherwise
+     * @returns true if synapse is defined and can be used, false otherwise
      */
-    isSynapseDefined() {
+    canUseSynapse() {
+      if (this.isCapacitorPluginDefined()) {
+        return false;
+      }
       return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
     }
     /**
@@ -786,7 +789,7 @@
         this.webPlugin.readFile(options).then((file) => success(file)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.readFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.readFile(options).then(success).catch(error);
@@ -797,7 +800,7 @@
         this.webPlugin.writeFile(options).then((result) => success(result)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -808,7 +811,7 @@
         this.webPlugin.appendFile(options).then(() => success()).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.appendFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.appendFile(options).then(success).catch(error);
@@ -819,7 +822,7 @@
         this.webPlugin.deleteFile(options).then(() => success()).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -830,7 +833,7 @@
         this.webPlugin.mkdir(options).then(() => success()).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.mkdir(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.mkdir(options).then(success).catch(error);
@@ -841,7 +844,7 @@
         this.webPlugin.rmdir(options).then(() => success()).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -852,7 +855,7 @@
         this.webPlugin.readdir(options).then((res) => success(res)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.readdir(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.readdir(options).then(success).catch(error);
@@ -863,7 +866,7 @@
         this.webPlugin.getUri(options).then((res) => success(res)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.getUri(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.getUri(options).then(success).catch(error);
@@ -874,7 +877,7 @@
         this.webPlugin.stat(options).then((res) => success(res)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.stat(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.stat(options).then(success).catch(error);
@@ -885,7 +888,7 @@
         this.webPlugin.rename(options).then(() => success()).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.rename(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.rename(options).then(success).catch(error);
@@ -896,7 +899,7 @@
         this.webPlugin.copy(options).then((res) => success(res)).catch((err) => error(err));
         return;
       }
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         CapacitorUtils.Synapse.Filesystem.copy(success, error, options);
       } else {
         Capacitor.Plugins.Filesystem.copy(options).then(success).catch(error);
@@ -906,7 +909,7 @@
      * @returns true if should use the web implementation
      */
     shouldUseCordovaWebImplementation() {
-      if (this.isSynapseDefined()) {
+      if (this.canUseSynapse()) {
         return false;
       }
       if (this.isCapacitorPluginDefined()) {
@@ -921,9 +924,12 @@
       return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
     }
     /**
-     * @returns true if synapse is defined, false otherwise
+     * @returns true if synapse is defined and can be used, false otherwise
      */
-    isSynapseDefined() {
+    canUseSynapse() {
+      if (this.isCapacitorPluginDefined()) {
+        return false;
+      }
       return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
     }
   }

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -30,7 +30,7 @@ class LegacyCordovaBridge {
     let mkDirSuccess = () => {
       this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.mkdir(mkDirSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.mkdir(options).then(mkDirSuccess).catch(error);
@@ -43,7 +43,7 @@ class LegacyCordovaBridge {
       directory,
       recursive: true
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -69,7 +69,7 @@ class LegacyCordovaBridge {
       );
       success(directories, files);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readdir(readDirSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readdir(options).then(readDirSuccess).catch(error);
@@ -99,7 +99,7 @@ class LegacyCordovaBridge {
       type = this.getMimeType(res.name);
       this.readFile(readFileSuccess, error, path, void 0, void 0);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.stat(statSuccess, error, { path });
     } else {
       Capacitor.Plugins.Filesystem.stat({ path }).then(statSuccess).catch(error);
@@ -114,7 +114,7 @@ class LegacyCordovaBridge {
     let getUriSuccess = (res) => {
       success(res.uri);
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.getUri(getUriSuccess, error, options);
     } else {
       Capacitor.Plugins.Filesystem.getUri(options).then(getUriSuccess).catch(error);
@@ -128,7 +128,7 @@ class LegacyCordovaBridge {
       directory,
       recursive: true
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -140,7 +140,7 @@ class LegacyCordovaBridge {
       path: `${path}/${name}`,
       directory
     };
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -242,9 +242,12 @@ class LegacyCordovaBridge {
     return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
   }
   /**
-   * @returns true if synapse is defined, false otherwise
+   * @returns true if synapse is defined and can be used, false otherwise
    */
-  isSynapseDefined() {
+  canUseSynapse() {
+    if (this.isCapacitorPluginDefined()) {
+      return false;
+    }
     return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
   }
   /**
@@ -782,7 +785,7 @@ class OSFilePlugin {
       this.webPlugin.readFile(options).then((file) => success(file)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readFile(options).then(success).catch(error);
@@ -793,7 +796,7 @@ class OSFilePlugin {
       this.webPlugin.writeFile(options).then((result) => success(result)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.writeFile(options).then(success).catch(error);
@@ -804,7 +807,7 @@ class OSFilePlugin {
       this.webPlugin.appendFile(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.appendFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.appendFile(options).then(success).catch(error);
@@ -815,7 +818,7 @@ class OSFilePlugin {
       this.webPlugin.deleteFile(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.deleteFile(options).then(success).catch(error);
@@ -826,7 +829,7 @@ class OSFilePlugin {
       this.webPlugin.mkdir(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.mkdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.mkdir(options).then(success).catch(error);
@@ -837,7 +840,7 @@ class OSFilePlugin {
       this.webPlugin.rmdir(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rmdir(options).then(success).catch(error);
@@ -848,7 +851,7 @@ class OSFilePlugin {
       this.webPlugin.readdir(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.readdir(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.readdir(options).then(success).catch(error);
@@ -859,7 +862,7 @@ class OSFilePlugin {
       this.webPlugin.getUri(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.getUri(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.getUri(options).then(success).catch(error);
@@ -870,7 +873,7 @@ class OSFilePlugin {
       this.webPlugin.stat(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.stat(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.stat(options).then(success).catch(error);
@@ -881,7 +884,7 @@ class OSFilePlugin {
       this.webPlugin.rename(options).then(() => success()).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.rename(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.rename(options).then(success).catch(error);
@@ -892,7 +895,7 @@ class OSFilePlugin {
       this.webPlugin.copy(options).then((res) => success(res)).catch((err) => error(err));
       return;
     }
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       CapacitorUtils.Synapse.Filesystem.copy(success, error, options);
     } else {
       Capacitor.Plugins.Filesystem.copy(options).then(success).catch(error);
@@ -902,7 +905,7 @@ class OSFilePlugin {
    * @returns true if should use the web implementation
    */
   shouldUseCordovaWebImplementation() {
-    if (this.isSynapseDefined()) {
+    if (this.canUseSynapse()) {
       return false;
     }
     if (this.isCapacitorPluginDefined()) {
@@ -917,9 +920,12 @@ class OSFilePlugin {
     return typeof Capacitor !== "undefined" && typeof Capacitor.Plugins !== "undefined" && typeof Capacitor.Plugins.Filesystem !== "undefined";
   }
   /**
-   * @returns true if synapse is defined, false otherwise
+   * @returns true if synapse is defined and can be used, false otherwise
    */
-  isSynapseDefined() {
+  canUseSynapse() {
+    if (this.isCapacitorPluginDefined()) {
+      return false;
+    }
     return typeof CapacitorUtils !== "undefined" && typeof CapacitorUtils.Synapse !== "undefined" && typeof CapacitorUtils.Synapse.Filesystem !== "undefined";
   }
 }

--- a/packages/outsystems-wrapper/src/legacyCordova.ts
+++ b/packages/outsystems-wrapper/src/legacyCordova.ts
@@ -18,7 +18,7 @@ class LegacyCordovaBridge {
             this.getFileUri(getUriSuccess, error, name, path, isInternal, isTemporary)
         }
         
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.mkdir(mkDirSuccess, error, options)
         } else {
@@ -38,7 +38,7 @@ class LegacyCordovaBridge {
             recursive: true
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options)
         } else {
@@ -72,7 +72,7 @@ class LegacyCordovaBridge {
             success(directories, files);
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.readdir(readDirSuccess, error, options)
         } else {
@@ -112,7 +112,7 @@ class LegacyCordovaBridge {
             this.readFile(readFileSuccess, error, path, undefined, undefined)
         }
         
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.stat(statSuccess, error, {path: path})
         } else {
@@ -134,7 +134,7 @@ class LegacyCordovaBridge {
             success(res.uri)
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.getUri(getUriSuccess, error, options)
         } else {
@@ -154,7 +154,7 @@ class LegacyCordovaBridge {
             recursive: true
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options)
         } else {
@@ -172,7 +172,7 @@ class LegacyCordovaBridge {
           directory
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options)
         } else {
@@ -305,12 +305,16 @@ class LegacyCordovaBridge {
     }
     
     /**
-     * @returns true if synapse is defined, false otherwise
+     * @returns true if synapse is defined and can be used, false otherwise
      */
-    private isSynapseDefined(): boolean {
-        // currently Synapse doesn't work in MABS 12 builds with Capacitor npm package
-        //  But it works with cordova via Github repository
-        //  So we need to call the Capacitor plugin directly; hence the need for this method
+    private canUseSynapse(): boolean {
+        if (this.isCapacitorPluginDefined()) {
+            // The Capacitor and Cordova plugins have parameters in the wrong order
+            // (Cordova declares options after callbacks in bridge, Capacitor uses Promises which means options come before callbacks)
+            // This makes it impossible to use Synapse because the API signatures are not the same.
+            //  Will only use Synapse for Cordova, which is as it was setup before.
+            return false
+        }
         // @ts-ignore
         return typeof (CapacitorUtils) !== "undefined" && typeof (CapacitorUtils.Synapse) !== "undefined" && typeof (CapacitorUtils.Synapse.Filesystem) !== "undefined"
     }

--- a/packages/outsystems-wrapper/src/wrapper.ts
+++ b/packages/outsystems-wrapper/src/wrapper.ts
@@ -16,7 +16,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.readFile(success, error, options)
         } else {
@@ -35,7 +35,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.writeFile(success, error, options)
         } else {
@@ -54,7 +54,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.appendFile(success, error, options)
         } else {
@@ -74,7 +74,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.deleteFile(success, error, options)
         } else {
@@ -93,7 +93,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.mkdir(success, error, options)
         } else {
@@ -112,7 +112,7 @@ class OSFilePlugin {
             return
         }
         
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.rmdir(success, error, options)
         } else {
@@ -131,7 +131,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.readdir(success, error, options)
         } else {
@@ -150,7 +150,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.getUri(success, error, options)
         } else {
@@ -169,7 +169,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.stat(success, error, options)
         } else {
@@ -188,7 +188,7 @@ class OSFilePlugin {
             return
         }
 
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.rename(success, error, options)
         } else {
@@ -207,7 +207,7 @@ class OSFilePlugin {
             return
         }
         
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // @ts-ignore
             CapacitorUtils.Synapse.Filesystem.copy(success, error, options)
         } else {
@@ -222,7 +222,7 @@ class OSFilePlugin {
      * @returns true if should use the web implementation
      */
     private shouldUseCordovaWebImplementation(): boolean {
-        if (this.isSynapseDefined()) {
+        if (this.canUseSynapse()) {
             // synapse defined <-> native mobile app <-> should use cordova web implementation
             return false
         }
@@ -243,12 +243,16 @@ class OSFilePlugin {
     }
 
     /**
-     * @returns true if synapse is defined, false otherwise
+     * @returns true if synapse is defined and can be used, false otherwise
      */
-    private isSynapseDefined(): boolean {
-        // currently Synapse doesn't work in MABS 12 builds with Capacitor npm package
-        //  But it works with cordova via Github repository
-        //  So we need to call the Capacitor plugin directly; hence the need for this method
+    private canUseSynapse(): boolean {
+        if (this.isCapacitorPluginDefined()) {
+            // The Capacitor and Cordova plugins have parameters in the wrong order
+            // (Cordova declares options after callbacks in bridge, Capacitor uses Promises which means options come before callbacks)
+            // This makes it impossible to use Synapse because the API signatures are not the same.
+            //  Will only use Synapse for Cordova, which is as it was setup before.
+            return false
+        }
         // @ts-ignore
         return typeof (CapacitorUtils) !== "undefined" && typeof (CapacitorUtils.Synapse) !== "undefined" && typeof (CapacitorUtils.Synapse.Filesystem) !== "undefined"
     }


### PR DESCRIPTION
## Description

This PR fixes how Synapse is being used in this Plugin's OutSystems wrapper.

Synapse requires both plugin APIs to match, however the order of parameters from the Cordova plugin bridge and the Capacitor Plugin API differs. 

The wrapper was assuming the order of parameters for Cordova. Synapse wasn't available at runtime previously for Capacitor OutSystems apps, but now it is, and when we try to use it, the Capacitor Plugin doesn't get called appropriately because the parameter order is wrong.

No other plugin that uses synapse has this issue - geolocation, file-transfer and file-viewer are all matching. The proper fix could involve fixing the order of the Cordova bridge to match all the other plugin bridges and capacitor plugins, but that would require additional logic in OutSystems blocks, to make sure existing apps don't get broken.

Since Synapse usage is optional (it was just to reduce some lines of code really), and it wasn't working for Capacitor beforehand, we're explicitly not using Synapse with the filesystem Capacitor Plugin.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4294

Note: These changes don't actually require a new release of the Cordova Plugin, since they're only in the wrapper.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [ ] iOS
- [x] JavaScript

## Tests

You can use the File Sample App from ODC MABS 12 build on iOS to test that everything is working. You can't use Android at the moment because of an existing issue.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
