### PR TITLE
RMET-4413 :: File & File Transfer & File Viewer Plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.2]
 
-### 01-07-2025
+### 01-09-2025
 
-- Fix: Usage of Synapse in OutSystems wrapper.
+### Fixes
+
+- **iOS** Do not add trailing slash to files
+- Usage of Synapse in OutSystems wrapper.
 
 ## [1.0.1]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.filesystem",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.filesystem" version="1.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.filesystem" version="1.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFilePlugin</name>
     <description>OutSystems' cordova geolocation plugin</description>
     <author>OutSystems Inc</author>
@@ -60,7 +60,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONFilesystemLib" spec="1.0.0" />
+                <pod name="IONFilesystemLib" spec="1.0.1" />
             </pods>
         </podspec> 
     </platform>


### PR DESCRIPTION
## Description
Fixing bug introduced by https://github.com/ionic-team/ion-ios-filesystem/pull/5 where non-existing files would get a trailing slash added to them; this should only apply to directories.


## Context
https://outsystemsrd.atlassian.net/browse/RMET-4413


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests

You can use the File Sample App from ODC MABS 11 build on iOS to test that everything is working.

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
