### PR TITLE
fix: update to 1.1.2 of iOS lib that was built with Xcode 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### Unreleased
+## [1.1.1]
 
 ### Fixes
 
-- **iOS**: Bump `IONFilesystemLib` to `1.1.1` to fix inconsistent error codes when file is missing.
+- **iOS**: Bump `IONFilesystemLib` to `1.1.2` to fix inconsistent error codes when file is missing.
 
 ## [1.1.0]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.filesystem",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/package.json
+++ b/packages/cordova-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.outsystems.plugins.filesystem",
   "displayName": "Filesystem",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Filesystem plugin for Cordova",
   "scripts": {
     "lint": "npm run eslint && npm run prettier -- --check",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.filesystem" version="1.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.filesystem" version="1.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFilePlugin</name>
     <description>OutSystems' cordova geolocation plugin</description>
     <author>OutSystems Inc</author>
@@ -60,7 +60,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONFilesystemLib" spec="1.1.1" />
+                <pod name="IONFilesystemLib" spec="1.1.2" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- update to 1.1.2 of iOS lib that was built with Xcode 16

## Change Type
- [x] Fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
<!--- Give us more information about why you think this PR is needed, or what problems it fixes -->
<!--- Be sure to place links to related issues or discussions here -->

- MABS 11.2 builds use Xcode 16 and using a version of the library built with Xcode 26 can break builds.

## Tests or Reproductions
<!--- Include a link to a minimal test project that can be used to validate the changes -->
<!--- Alternatively, describe how you tested your changes in detail -->
<!--- The easier it is to test and validate your pull request, the faster it can be reviewed -->

- MABS 11.2 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=9557acca56ff95514581ec2eda13397cd208ab74&stg=dev

- MABS 12 build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=f8c0dea07c2e29ef8c6c04a4a041b79065fe5489&stg=dev

## Screenshots / Media
<!--- (Optional) Include screenshots, videos or other files relevant to the pull request -->

## Platforms Affected
- [ ] Android
- [x] iOS
- [ ] Web

## Notes / Comments
<!--- Put anything else here that would be good for us to know! -->
