### PR TITLE
fix(android): Remove kapt and custom maven repo

### DIFF
--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -9,13 +9,6 @@ buildscript {
     }
 }
 
-apply plugin: 'kotlin-kapt'
-allprojects {
-    repositories {
-        maven { url 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1' }
-    }
-}
-
 dependencies{
     implementation("io.ionic.libs:ionfilesystem-android:1.1.0@aar")
 


### PR DESCRIPTION
## Description

This plugin declares `kotlin-kapt` and an OutSystems Azure reference for maven that aren't used by this cordova plugin, so this PR removes it. The `kotlin-kapt` in particular would cause build failures with Android Gradle Plugin (AGP) version 9.

## Context

Noticed while doing some investigations for https://outsystemsrd.atlassian.net/browse/RMET-5288. While I don't think AGP 9 won't be used by Cordova for MABS 13 (and this plugin in particular isn't used for ODC Capacitor as it has a Capacitor Counterpart), it doesn't hurt to remove the code.

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Refer to the following successful MABS build: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=387f076c7ca401992413ba969f4fed2a7fa4cf96&stg=dev

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Code follows code style of this project
- [ ] Using [conventional commits](https://www.conventionalcommits.org/)
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
